### PR TITLE
fix: graceful error handling for unreadable data files

### DIFF
--- a/src/data-loading.jl
+++ b/src/data-loading.jl
@@ -42,7 +42,12 @@ function load_data_metadata(filepath::String, max_rows = 1000)
         data = matread(filepath)
         return extract_metadata(data)
     elseif (ext == ".pkl" || ext == ".pickle")
-        data = Pickle.load(filepath, proto = 5)
+        data = try
+            Pickle.load(filepath, proto = 5)
+        catch e
+            @warn "could not load pickle file $filepath: $e"
+            return nothing
+        end
         return extract_metadata(data)
     else
         # Use R only to read the data (no metadata extraction in R)
@@ -139,7 +144,7 @@ function extract_metadata(data; labels = nothing)
             "var_labels" => labels,
             "samples" => samples
         )
-    else
+    elseif data isa AbstractDataFrame
         # Handle DataFrame-like objects (original logic)
         var_names = names(data)
         
@@ -167,5 +172,8 @@ function extract_metadata(data; labels = nothing)
             "var_labels" => labels,
             "samples" => samples
         )
+    else
+        @warn "unsupported data type $(typeof(data)) for metadata extraction"
+        return nothing
     end
 end

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -240,8 +240,14 @@ function scan_data_files(data_files::Vector{String};
     for (idx, filepath) in enumerate(data_files)
         print("  [$idx/$(length(data_files))] $filepath ... ")
         
-        matches = scan_data_file(filepath; strict=strict, custom_terms=custom_terms)
-        
+        matches = try
+            scan_data_file(filepath; strict=strict, custom_terms=custom_terms)
+        catch e
+            @warn "scan_data_file failed for $filepath: $e"
+            println("✗ error (skipped)")
+            PIIMatch[]
+        end
+
         if isempty(matches)
             println("✓ clean")
         else

--- a/test/test_data_loading.jl
+++ b/test/test_data_loading.jl
@@ -198,3 +198,40 @@ end
 
     @test Set(out["var_names"]) == Set(["mixed_types", "nested_dict", "arrays"])
 end
+
+@testitem "extract_metadata returns nothing for Vector{Any}" begin
+    # Vector{Any} is what Pickle returns for list-of-records; not a DataFrame or Dict
+    result = PackageScanner.extract_metadata(Any[1, 2, 3])
+    @test isnothing(result)
+end
+
+@testitem "load_data_metadata returns nothing for corrupt pickle" begin
+    tmpdir = mktempdir()
+    bad_pkl = joinpath(tmpdir, "corrupt.pkl")
+    write(bad_pkl, "not a pickle file")
+    result = PackageScanner.load_data_metadata(bad_pkl)
+    @test isnothing(result)
+end
+
+@testitem "scan_data_files skips unreadable files gracefully" begin
+    tmpdir = mktempdir()
+
+    # Good file with PII
+    good_file = joinpath(tmpdir, "survey.csv")
+    open(good_file, "w") do io
+        println(io, "name,age")
+        println(io, "Alice,30")
+    end
+
+    # Bad pickle that will fail to parse
+    bad_file = joinpath(tmpdir, "broken.pkl")
+    write(bad_file, "not a pickle")
+
+    matches = redirect_stdout(devnull) do
+        PackageScanner.scan_data_files([good_file, bad_file])
+    end
+
+    # Good file still scanned; bad file skipped without crash
+    @test any(m -> m.filepath == good_file, matches)
+    @test !any(m -> m.filepath == bad_file, matches)
+end


### PR DESCRIPTION
## Summary

- `extract_metadata`: added `else` fallback for unknown types (e.g. `Vector{Any}` from pickle) that warns + returns `nothing` instead of calling `names()` on a non-DataFrame
- `load_data_metadata`: wrapped `Pickle.load` in try/catch; returns `nothing` on parse failure
- `scan_data_files`: wrapped per-file `scan_data_file` call in try/catch; bad files print `✗ error (skipped)` and loop continues

Root cause of CI crash (`JPE-Sullivan-20231305`): a `.pickle` file returned `Vector{Any}`, which fell through to the DataFrame branch and hit `MethodError: no method matching names(::Vector{Any})`, killing the entire run.

## Test plan

- [x] `extract_metadata returns nothing for Vector{Any}`
- [x] `load_data_metadata returns nothing for corrupt pickle`
- [x] `scan_data_files skips unreadable files gracefully`

All 3 new tests pass; no regressions in existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)